### PR TITLE
[Bug] Remove Authorization header in signin request

### DIFF
--- a/src/core/services/http-server/index.js
+++ b/src/core/services/http-server/index.js
@@ -7,7 +7,7 @@ class HttpServer extends HttpClient {
     super(`${config.API_URL}/api/`);
 
     this.interceptRequest((request) => {
-      if (store.token) {
+      if (store.token && request.url !== 'auth/login/') {
         request.headers.common.Authorization = `Bearer ${store.token}`;
       }
       return request;

--- a/src/core/services/http-server/index.js
+++ b/src/core/services/http-server/index.js
@@ -7,7 +7,7 @@ class HttpServer extends HttpClient {
     super(`${config.API_URL}/api/`);
 
     this.interceptRequest((request) => {
-      if (store.token && request.url !== 'auth/login/') {
+      if (store.token && request.url !== 'auth/') {
         request.headers.common.Authorization = `Bearer ${store.token}`;
       }
       return request;


### PR DESCRIPTION
## Description
A condition to check that the authorization request shouldn't be added during signin.

Fixes #29 


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [x] I have added tests that prove my fix is effective and that this feature works
- [x] New and existing unit tests pass locally with my changes
